### PR TITLE
split is deprecated since 5.3.0 using explode instead

### DIFF
--- a/php/chatterbotapi.php
+++ b/php/chatterbotapi.php
@@ -157,7 +157,7 @@
             $dataDigest = md5($dataToDigest);
             $this->vars['icognocheck'] = $dataDigest;
             $response = _utils_post($this->bot->getUrl(), $this->vars);
-            $responseValues = split("\r", $response);
+            $responseValues = explode("\r", $response);
             //self.vars['??'] = _utils_string_at_index($responseValues, 0);
             $this->vars['sessionid'] = _utils_string_at_index($responseValues, 1);
             $this->vars['logurl'] = _utils_string_at_index($responseValues, 2);


### PR DESCRIPTION
Sending patch of https://github.com/Schumix/ChatterBotApi/pull/3
